### PR TITLE
Dl 6602

### DIFF
--- a/app/uk/gov/hmrc/entrydeclarationoutcome/housekeeping/HousekeepingScheduler.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/housekeeping/HousekeepingScheduler.scala
@@ -43,7 +43,7 @@ class HousekeepingScheduler @Inject()(
     override val holdLockFor: JodaDuration = JodaDuration.millis(appConfig.housekeepingLockDuration.toMillis)
   }
 
-  scheduler.schedule(appConfig.housekeepingRunInterval, appConfig.housekeepingRunInterval) {
+  scheduler.scheduleWithFixedDelay(appConfig.housekeepingRunInterval, appConfig.housekeepingRunInterval)(() => {
     exclusiveTimePeriodLock
       .tryToAcquireOrRenewLock {
         housekeeper.housekeep()
@@ -51,5 +51,5 @@ class HousekeepingScheduler @Inject()(
       .andThen {
         case Failure(e) => logger.error("Failed housekeeping", e)
       }
-  }
+  })
 }

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin, ScalafmtCorePlugin)
   .disablePlugins(JUnitXmlReportPlugin)
   .settings(
-    scalaVersion := "2.12.12",
+    scalaVersion := "2.12.13",
     majorVersion := 0,
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     dependencyOverrides ++= AppDependencies.overrides,

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 
   Seq(
     ScoverageKeys.coverageExcludedPackages := excludedPackages.mkString(";"),
-    ScoverageKeys.coverageMinimum := 80,
+    ScoverageKeys.coverageMinimumStmtTotal := 80,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true
   )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -25,9 +25,9 @@ play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 # Primary entry point for all HTTP requests on Play applications
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 
-# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
+# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
 # An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
+play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 
 # Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.graphite.GraphiteMetricsModule` or create your own.
 # A metric filter must be provided

--- a/it/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeSubmissionControllerISpec.scala
+++ b/it/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeSubmissionControllerISpec.scala
@@ -16,8 +16,8 @@
 
 package uk.gov.hmrc.entrydeclarationoutcome.controllers
 
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.WordSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.http.HeaderNames._
 import play.api.http.MimeTypes
@@ -27,7 +27,7 @@ import play.api.libs.ws.WSClient
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import play.api.{Application, Environment, Mode}
 
-class OutcomeSubmissionControllerISpec extends WordSpec with GuiceOneServerPerSuite {
+class OutcomeSubmissionControllerISpec extends AnyWordSpec with GuiceOneServerPerSuite {
 
   val wsClient: WSClient = app.injector.instanceOf[WSClient]
 

--- a/it/uk/gov/hmrc/entrydeclarationoutcome/housekeeping/HousekeepingSchedulerISpec.scala
+++ b/it/uk/gov/hmrc/entrydeclarationoutcome/housekeeping/HousekeepingSchedulerISpec.scala
@@ -19,9 +19,11 @@ package uk.gov.hmrc.entrydeclarationoutcome.housekeeping
 import akka.actor.{ActorSystem, Scheduler}
 import akka.testkit.{TestKit, TestProbe}
 import com.miguno.akka.testing.VirtualTime
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Milliseconds, Span}
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -36,7 +38,7 @@ import scala.concurrent.duration._
 
 class HousekeepingSchedulerISpec
     extends TestKit(ActorSystem("HosekeepingActorSpec"))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with FutureAwaits
     with DefaultAwaitTimeout

--- a/it/uk/gov/hmrc/entrydeclarationoutcome/housekeeping/HousekeepingSchedulerISpec.scala
+++ b/it/uk/gov/hmrc/entrydeclarationoutcome/housekeeping/HousekeepingSchedulerISpec.scala
@@ -37,7 +37,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class HousekeepingSchedulerISpec
-    extends TestKit(ActorSystem("HosekeepingActorSpec"))
+    extends TestKit(ActorSystem("HousekeepingActorSpec"))
     with AnyWordSpecLike
     with Matchers
     with FutureAwaits

--- a/it/uk/gov/hmrc/entrydeclarationoutcome/repositories/HousekeepingRepoISpec.scala
+++ b/it/uk/gov/hmrc/entrydeclarationoutcome/repositories/HousekeepingRepoISpec.scala
@@ -17,7 +17,8 @@
 package uk.gov.hmrc.entrydeclarationoutcome.repositories
 
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.{DefaultAwaitTimeout, FutureAwaits, Injecting}
@@ -28,7 +29,7 @@ import uk.gov.hmrc.entrydeclarationoutcome.models.HousekeepingStatus
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class HousekeepingRepoISpec
-  extends WordSpec
+  extends AnyWordSpec
     with Matchers
     with FutureAwaits
     with DefaultAwaitTimeout

--- a/it/uk/gov/hmrc/entrydeclarationoutcome/repositories/OutcomeRepoISpec.scala
+++ b/it/uk/gov/hmrc/entrydeclarationoutcome/repositories/OutcomeRepoISpec.scala
@@ -20,9 +20,11 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 
-import org.scalatest.Matchers.{convertToAnyShouldWrapper, not}
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.{Assertion, BeforeAndAfterAll, WordSpec}
+import org.scalatest.matchers.must.Matchers.not
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{Assertion, BeforeAndAfterAll}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
@@ -40,7 +42,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Random
 
 class OutcomeRepoISpec
-    extends WordSpec
+    extends AnyWordSpec
     with DefaultAwaitTimeout
     with GuiceOneAppPerSuite
     with BeforeAndAfterAll

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -17,37 +17,40 @@ import play.core.PlayVersion.current
 import sbt._
 
 object AppDependencies {
-  val bootstrapVersion = "5.4.0"
+  val bootstrapVersion = "5.16.0"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% "simple-reactivemongo"      % "8.0.0-play-27",
-    "uk.gov.hmrc"       %% "mongo-lock"                % "7.0.0-play-27",
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-27" % bootstrapVersion,
+    "uk.gov.hmrc"       %% "simple-reactivemongo"      % "8.0.0-play-28",
+    "uk.gov.hmrc"       %% "mongo-lock"                % "7.0.0-play-28",
+    "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % bootstrapVersion,
     "org.typelevel"     %% "cats-core"                 % "2.6.1",
     "com.chuusai"       %% "shapeless"                 % "2.3.7",
-    "org.reactivemongo" %% "reactivemongo-akkastream"  % "0.20.13"
+    "org.reactivemongo" %% "reactivemongo-akkastream"  % "1.0.7"
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"            %% "bootstrap-backend-play-27" % bootstrapVersion % "test, it",
-    "com.typesafe.play"      %% "play-test"                 % current          % "test",
-    "org.pegdown"            % "pegdown"                    % "1.6.0"          % "test, it",
-    "org.scalatestplus.play" %% "scalatestplus-play"        % "4.0.3"          % "test, it",
-    "org.scalamock"          %% "scalamock"                 % "5.1.0"          % "test, it",
-    "org.scalacheck"         %% "scalacheck"                % "1.15.4"         % "test, it",
-    "com.github.tomakehurst" % "wiremock"                   % "2.27.2"         % "test, it",
-    "com.miguno.akka"        %% "akka-mock-scheduler"       % "0.5.5"          % "test, it",
-    "com.typesafe.akka"      %% "akka-testkit"              % "2.6.15"         % "test, it"
+    "uk.gov.hmrc"                  %% "bootstrap-test-play-28" % bootstrapVersion % "test, it",
+    "com.typesafe.play"            %% "play-test"              % current          % "test",
+    "org.pegdown"                  %  "pegdown"                % "1.6.0"          % "test, it",
+    "org.scalatestplus.play"       %% "scalatestplus-play"     % "5.1.0"          % "test, it",
+    "org.scalamock"                %% "scalamock"              % "5.1.0"          % "test, it",
+    "org.scalatestplus"            %% "scalacheck-1-15"        % "3.2.10.0"       % "test, it",
+    "com.github.tomakehurst"       %  "wiremock-jre8"          % "2.31.0"         % "test, it",
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.12.5"         % "test, it",
+    "com.miguno.akka"              %% "akka-mock-scheduler"    % "0.5.5"          % "test, it",
+    "com.typesafe.akka"            %% "akka-testkit"           % "2.6.17"         % "test, it"
   )
 
   // Fixes a transitive dependency clash after upgrading to sbt 1.3.4
   val overrides: Seq[ModuleID] = {
-    val jettyFromWiremockVersion = "9.2.24.v20180105"
+    val jettyFromWiremockVersion = "9.4.44.v20210927"
     Seq(
-      "com.typesafe.akka"           %% "akka-actor"        % "2.6.15",
-      "com.typesafe.akka"           %% "akka-stream"       % "2.6.15",
-      "com.typesafe.akka"           %% "akka-protobuf"     % "2.6.15",
-      "com.typesafe.akka"           %% "akka-slf4j"        % "2.6.15",
+      "com.typesafe.akka"           %% "akka-actor"                 % "2.6.17",
+      "com.typesafe.akka"           %% "akka-stream"                % "2.6.17",
+      "com.typesafe.akka"           %% "akka-protobuf"              % "2.6.17",
+      "com.typesafe.akka"           %% "akka-slf4j"                 % "2.6.17",
+      "com.typesafe.akka"           %% "akka-serialization-jackson" % "2.6.17",
+      "com.typesafe.akka"           %% "akka-actor-typed"           % "2.6.17",
       "org.eclipse.jetty"           % "jetty-client"       % jettyFromWiremockVersion,
       "org.eclipse.jetty"           % "jetty-continuation" % jettyFromWiremockVersion,
       "org.eclipse.jetty"           % "jetty-http"         % jettyFromWiremockVersion,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -25,7 +25,7 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % bootstrapVersion,
     "org.typelevel"     %% "cats-core"                 % "2.6.1",
     "com.chuusai"       %% "shapeless"                 % "2.3.7",
-    "org.reactivemongo" %% "reactivemongo-akkastream"  % "1.0.7"
+    "org.reactivemongo" %% "reactivemongo-akkastream"  % "0.20.13"
   )
 
   val test: Seq[ModuleID] = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,13 +3,13 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.1")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/connectors/ApiSubscriptionFieldsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/connectors/ApiSubscriptionFieldsConnectorSpec.scala
@@ -21,7 +21,9 @@ import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, urlPathE
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.http.Fault
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.Status.{NOT_FOUND, OK}
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -35,7 +37,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class ApiSubscriptionFieldsConnectorSpec
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with FutureAwaits
     with DefaultAwaitTimeout

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/AuthorisedControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/AuthorisedControllerSpec.scala
@@ -17,9 +17,9 @@
 package uk.gov.hmrc.entrydeclarationoutcome.controllers
 
 import org.scalamock.matchers.ArgCapture.CaptureOne
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.WordSpec
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.http.{HeaderNames, Status}
 import play.api.libs.json.Json
 import play.api.mvc._
@@ -33,7 +33,7 @@ import scala.concurrent.Future
 import scala.xml.Node
 
 class AuthorisedControllerSpec
-    extends WordSpec
+    extends AnyWordSpec
     with Status
     with HeaderNames
     with ResultExtractors

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/DocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/DocumentationControllerSpec.scala
@@ -17,8 +17,10 @@
 package uk.gov.hmrc.entrydeclarationoutcome.controllers
 
 import controllers.Assets
-import org.scalatest.Matchers.{convertToAnyShouldWrapper, have}
-import org.scalatest.{Assertion, WordSpec}
+import org.scalatest.Assertion
+import org.scalatest.matchers.must.Matchers.have
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsValue
@@ -29,7 +31,7 @@ import play.mvc.Http.MimeTypes
 import uk.gov.hmrc.entrydeclarationoutcome.config.MockAppConfig
 import uk.gov.hmrc.entrydeclarationoutcome.housekeeping.HousekeepingScheduler
 
-class DocumentationControllerSpec extends WordSpec with MockAppConfig with Injecting with GuiceOneAppPerSuite {
+class DocumentationControllerSpec extends AnyWordSpec with MockAppConfig with Injecting with GuiceOneAppPerSuite {
   override lazy val app: Application = new GuiceApplicationBuilder()
     .in(Environment.simple(mode = Mode.Dev))
     .disable[HousekeepingScheduler]

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/HousekeepingControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/HousekeepingControllerSpec.scala
@@ -16,8 +16,8 @@
 
 package uk.gov.hmrc.entrydeclarationoutcome.controllers
 
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.WordSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.http.MimeTypes
 import play.api.libs.json.Json
 import play.api.test.Helpers._
@@ -28,7 +28,7 @@ import uk.gov.hmrc.entrydeclarationoutcome.services.MockHousekeepingService
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class HousekeepingControllerSpec extends WordSpec with MockHousekeepingService {
+class HousekeepingControllerSpec extends AnyWordSpec with MockHousekeepingService {
 
   val controller = new HousekeepingController(Helpers.stubControllerComponents(), mockHousekeepingService)
 

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeRetrievalControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeRetrievalControllerSpec.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.entrydeclarationoutcome.controllers
 
 import java.time.Instant
 
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.WordSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.http.MimeTypes
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Helpers}
@@ -33,7 +33,7 @@ import scala.concurrent.Future
 import scala.xml.Node
 
 class OutcomeRetrievalControllerSpec
-    extends WordSpec
+    extends AnyWordSpec
     with MockOutcomeRetrievalService
     with MockAuthService
     with MockReportSender {

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeSubmissionControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeSubmissionControllerSpec.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.entrydeclarationoutcome.controllers
 
 import java.time.Duration
 
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.WordSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.Json
 import play.api.test.Helpers.{contentType, _}
 import play.api.test.{FakeRequest, Helpers}
@@ -32,7 +32,7 @@ import uk.gov.hmrc.entrydeclarationoutcome.utils.SaveError
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class OutcomeSubmissionControllerSpec extends WordSpec with MockOutcomeSubmissionService with MockReportSender {
+class OutcomeSubmissionControllerSpec extends AnyWordSpec with MockOutcomeSubmissionService with MockReportSender {
 
   private val controller =
     new OutcomeSubmissionController(Helpers.stubControllerComponents(), mockOutcomeSubmissionService, mockReportSender)

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/test/TestOutcomeRetrievalControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/test/TestOutcomeRetrievalControllerSpec.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.entrydeclarationoutcome.controllers.test
 
 import java.time.Instant
 
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.WordSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Helpers}
@@ -30,7 +30,7 @@ import uk.gov.hmrc.entrydeclarationoutcome.services.MockOutcomeRetrievalService
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class TestOutcomeRetrievalControllerSpec extends WordSpec with MockOutcomeRetrievalService {
+class TestOutcomeRetrievalControllerSpec extends AnyWordSpec with MockOutcomeRetrievalService {
 
   val controller =
     new TestOutcomeRetrievalController(Helpers.stubControllerComponents(), mockOutcomeXmlRetrievalService)

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/models/FullOutcomeSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/models/FullOutcomeSpec.scala
@@ -18,11 +18,11 @@ package uk.gov.hmrc.entrydeclarationoutcome.models
 
 import java.time.Instant
 
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.WordSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.Json
 
-class FullOutcomeSpec extends WordSpec {
+class FullOutcomeSpec extends AnyWordSpec {
 
   val fullOutcome: FullOutcome = FullOutcome(
     OutcomeReceived(

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/OutcomeReportSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/OutcomeReportSpec.scala
@@ -18,14 +18,14 @@ package uk.gov.hmrc.entrydeclarationoutcome.reporting
 
 import java.time.{Clock, Duration, Instant, ZoneOffset}
 
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.WordSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.{JsNumber, JsObject, Json}
 import uk.gov.hmrc.entrydeclarationoutcome.models.MessageType
 import uk.gov.hmrc.entrydeclarationoutcome.reporting.events.EventCode
 import uk.gov.hmrc.entrydeclarationoutcome.utils.Values.MkValues
 
-class OutcomeReportSpec extends WordSpec {
+class OutcomeReportSpec extends AnyWordSpec {
 
   val now: Instant = Instant.now
   val clock: Clock = Clock.fixed(now, ZoneOffset.UTC)

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/ReportSenderSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/ReportSenderSpec.scala
@@ -19,9 +19,9 @@ package uk.gov.hmrc.entrydeclarationoutcome.reporting
 import java.time.{Clock, Duration, Instant, ZoneOffset}
 
 import com.kenshoo.play.metrics.Metrics
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.WordSpec
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.JsObject
 import uk.gov.hmrc.entrydeclarationoutcome.logging.LoggingContext
 import uk.gov.hmrc.entrydeclarationoutcome.models.MessageType
@@ -34,7 +34,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.control.NoStackTrace
 
-class ReportSenderSpec extends WordSpec with MockAuditHandler with MockEventConnector with ScalaFutures {
+class ReportSenderSpec extends AnyWordSpec with MockAuditHandler with MockEventConnector with ScalaFutures {
 
   // To show that it uses the specified clock for generating events...
   val clock: Clock = Clock.offset(Clock.fixed(Instant.now, ZoneOffset.UTC), Duration.ofSeconds(30))

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/audit/AuditHandlerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/audit/AuditHandlerSpec.scala
@@ -18,8 +18,10 @@ package uk.gov.hmrc.entrydeclarationoutcome.reporting.audit
 
 import org.scalamock.matchers.ArgCapture.CaptureOne
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.Matchers.{convertToAnyShouldWrapper, not}
-import org.scalatest.{Inside, WordSpec}
+import org.scalatest.Inside
+import org.scalatest.matchers.must.Matchers.not
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.{JsObject, JsString}
 import uk.gov.hmrc.entrydeclarationoutcome.config.MockAppConfig
 import uk.gov.hmrc.http.HeaderCarrier
@@ -29,7 +31,7 @@ import uk.gov.hmrc.play.audit.model.ExtendedDataEvent
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class AuditHandlerSpec extends WordSpec with MockFactory with MockAppConfig with Inside {
+class AuditHandlerSpec extends AnyWordSpec with MockFactory with MockAppConfig with Inside {
 
   val appName         = "appname"
   val auditType       = "type"

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/audit/MockAuditHandler.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/audit/MockAuditHandler.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import scala.concurrent.Future
 
 trait MockAuditHandler extends MockFactory {
-  val mockAuditHandler = mock[AuditHandler]
+  val mockAuditHandler: AuditHandler = mock[AuditHandler]
 
   object MockAuditHandler {
     def audit(auditEvent: AuditEvent): CallHandler[Future[Unit]] =

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/events/EventConnectorSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/events/EventConnectorSpec.scala
@@ -22,7 +22,9 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.http.Fault
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
@@ -39,7 +41,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import scala.concurrent.ExecutionContext
 
 class EventConnectorSpec
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with FutureAwaits
     with DefaultAwaitTimeout

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/services/AuthServiceSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/services/AuthServiceSpec.scala
@@ -17,10 +17,11 @@
 package uk.gov.hmrc.entrydeclarationoutcome.services
 
 import org.scalamock.handlers.CallHandler
-import org.scalatest.Matchers.convertToAnyShouldWrapper
+import org.scalatest.Inside
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.time.{Millis, Span}
-import org.scalatest.{Inside, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.mvc.Headers
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.EmptyRetrieval
@@ -32,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NoStackTrace
 
 class AuthServiceSpec
-    extends WordSpec
+    extends AnyWordSpec
     with MockAuthConnector
     with MockApiSubscriptionFieldsConnector
     with ScalaFutures

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/services/HousekeepingServiceSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/services/HousekeepingServiceSpec.scala
@@ -19,9 +19,9 @@ package uk.gov.hmrc.entrydeclarationoutcome.services
 import java.time.{Clock, Instant, ZoneOffset}
 
 import com.kenshoo.play.metrics.Metrics
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.WordSpec
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.entrydeclarationoutcome.config.MockAppConfig
 import uk.gov.hmrc.entrydeclarationoutcome.models.HousekeepingStatus
 import uk.gov.hmrc.entrydeclarationoutcome.repositories.{MockHousekeepingRepo, MockOutcomeRepo}
@@ -32,7 +32,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class HousekeepingServiceSpec
-    extends WordSpec
+    extends AnyWordSpec
     with MockAppConfig
     with MockOutcomeRepo
     with MockHousekeepingRepo

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/services/OutcomeRetrievalServiceSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/services/OutcomeRetrievalServiceSpec.scala
@@ -20,9 +20,9 @@ import java.time.{Clock, Instant, ZoneOffset}
 
 import com.codahale.metrics.MetricRegistry
 import com.kenshoo.play.metrics.Metrics
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.WordSpec
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.entrydeclarationoutcome.config.MockAppConfig
 import uk.gov.hmrc.entrydeclarationoutcome.logging.LoggingContext
 import uk.gov.hmrc.entrydeclarationoutcome.models._
@@ -32,7 +32,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class OutcomeRetrievalServiceSpec extends WordSpec with MockOutcomeRepo with MockAppConfig with ScalaFutures {
+class OutcomeRetrievalServiceSpec extends AnyWordSpec with MockOutcomeRepo with MockAppConfig with ScalaFutures {
 
   val time: Instant = Instant.now
   val clock: Clock  = Clock.fixed(time, ZoneOffset.UTC)

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/services/OutcomeSubmissionServiceSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/services/OutcomeSubmissionServiceSpec.scala
@@ -19,9 +19,9 @@ package uk.gov.hmrc.entrydeclarationoutcome.services
 import java.time.{Clock, Instant, ZoneOffset}
 
 import com.kenshoo.play.metrics.Metrics
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.WordSpec
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.entrydeclarationoutcome.logging.LoggingContext
 import uk.gov.hmrc.entrydeclarationoutcome.models.{MessageType, OutcomeReceived}
 import uk.gov.hmrc.entrydeclarationoutcome.repositories.MockOutcomeRepo
@@ -30,7 +30,7 @@ import uk.gov.hmrc.entrydeclarationoutcome.utils.{MockMetrics, SaveError}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class OutcomeSubmissionServiceSpec extends WordSpec with MockOutcomeRepo with ScalaFutures {
+class OutcomeSubmissionServiceSpec extends AnyWordSpec with MockOutcomeRepo with ScalaFutures {
 
   val time: Instant         = Instant.now
   val receivedTime: Instant = time.minusSeconds(1)

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/utils/EnumJsonSpecSupport.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/utils/EnumJsonSpecSupport.scala
@@ -16,12 +16,12 @@
 
 package uk.gov.hmrc.entrydeclarationoutcome.utils
 
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.WordSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.{Format, Json}
 
 trait EnumJsonSpecSupport {
-  self: WordSpec =>
+  self: AnyWordSpec =>
 
   /**
     * Tests round-tripping

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/utils/EnumsSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/utils/EnumsSpec.scala
@@ -18,8 +18,9 @@ package uk.gov.hmrc.entrydeclarationoutcome.utils
 
 import cats.Show
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.{Inspectors, WordSpec}
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json._
 
 sealed trait Enum
@@ -39,7 +40,7 @@ object Foo {
   implicit def fmts[A: Format]: Format[Foo[A]] = Json.format[Foo[A]]
 }
 
-class EnumsSpec extends WordSpec with Inspectors {
+class EnumsSpec extends AnyWordSpec with Inspectors {
 
   import Enum._
 

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/utils/TimerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/utils/TimerSpec.scala
@@ -20,15 +20,16 @@ import java.time.{Clock, Duration, Instant, ZoneOffset}
 
 import com.codahale.metrics.MetricRegistry
 import com.kenshoo.play.metrics.Metrics
-import org.scalatest.Matchers.{be, convertToAnyShouldWrapper}
-import play.api.test.Helpers.{await, defaultAwaitTimeout}
-import org.scalatest.WordSpec
+import org.scalatest.matchers.must.Matchers.be
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.Logging
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class TimerSpec extends WordSpec with Timer with Logging {
+class TimerSpec extends AnyWordSpec with Timer with Logging {
   val metrics: Metrics   = new MockMetrics
   val startTime: Instant = Instant.now
   val endTime: Instant   = startTime.plusSeconds(1)


### PR DESCRIPTION
Play 28 upgrade
Scala upgrade to 2.12.13

Note - unable to upgrade reactivemongo-akkastream to 1.0.7 as causing it test to fail
Unit, IT and ATs all pass using this version