### PR TITLE
Dl 7067

### DIFF
--- a/app/uk/gov/hmrc/entrydeclarationoutcome/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/config/AppConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/config/DIModule.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/config/DIModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/connectors/ApiSubscriptionFieldsConnector.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/connectors/ApiSubscriptionFieldsConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/AuthorisedController.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/AuthorisedController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/DocumentationController.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/DocumentationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/HousekeepingController.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/HousekeepingController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeRetrievalController.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeRetrievalController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeSubmissionController.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeSubmissionController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/test/TestOutcomeRetrievalController.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/test/TestOutcomeRetrievalController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/housekeeping/Housekeeper.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/housekeeping/Housekeeper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/housekeeping/HousekeepingScheduler.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/housekeeping/HousekeepingScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/logging/ContextLogger.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/logging/ContextLogger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/logging/LoggingContext.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/logging/LoggingContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/models/FullOutcome.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/models/FullOutcome.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/models/HousekeepingEnabled.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/models/HousekeepingEnabled.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/models/HousekeepingStatus.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/models/HousekeepingStatus.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/models/InstantFormatter.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/models/InstantFormatter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/models/MessageType.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/models/MessageType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/models/Outcome.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/models/Outcome.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/models/OutcomeMetadata.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/models/OutcomeMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/models/OutcomeReceived.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/models/OutcomeReceived.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/models/OutcomeXml.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/models/OutcomeXml.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/models/StandardError.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/models/StandardError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/EventSources.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/EventSources.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/OutcomeReport.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/OutcomeReport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/Report.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/Report.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/ReportSender.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/ReportSender.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/audit/AuditEvent.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/audit/AuditEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/audit/AuditHandler.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/audit/AuditHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/events/Event.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/events/Event.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/events/EventCode.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/events/EventCode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/events/EventConnector.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/reporting/events/EventConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/repositories/HousekeepingRepo.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/repositories/HousekeepingRepo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/repositories/LockRepositoryProvider.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/repositories/LockRepositoryProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/repositories/OutcomePersisted.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/repositories/OutcomePersisted.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/repositories/OutcomeRepo.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/repositories/OutcomeRepo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/repositories/PersistableDateTime.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/repositories/PersistableDateTime.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/services/AuthService.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/services/AuthService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/services/HousekeepingService.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/services/HousekeepingService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/services/OutcomeRetrievalService.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/services/OutcomeRetrievalService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/services/OutcomeSubmissionService.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/services/OutcomeSubmissionService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/utils/Enums.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/utils/Enums.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/utils/PagerDutyLogger.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/utils/PagerDutyLogger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/utils/SaveError.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/utils/SaveError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/utils/Timer.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/utils/Timer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/utils/Values.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/utils/Values.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val coverageSettings: Seq[Setting[_]] = {
   )
 }
 
-val silencerVersion = "1.7.1"
+val silencerVersion = "1.7.8"
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin, ScalafmtCorePlugin)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2021 HM Revenue & Customs
+# Copyright 2022 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/it/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeSubmissionControllerISpec.scala
+++ b/it/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeSubmissionControllerISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/it/uk/gov/hmrc/entrydeclarationoutcome/housekeeping/HousekeepingSchedulerISpec.scala
+++ b/it/uk/gov/hmrc/entrydeclarationoutcome/housekeeping/HousekeepingSchedulerISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/it/uk/gov/hmrc/entrydeclarationoutcome/repositories/HousekeepingRepoISpec.scala
+++ b/it/uk/gov/hmrc/entrydeclarationoutcome/repositories/HousekeepingRepoISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/it/uk/gov/hmrc/entrydeclarationoutcome/repositories/OutcomeRepoISpec.scala
+++ b/it/uk/gov/hmrc/entrydeclarationoutcome/repositories/OutcomeRepoISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -17,13 +17,13 @@ import play.core.PlayVersion.current
 import sbt._
 
 object AppDependencies {
-  val bootstrapVersion = "5.16.0"
+  val bootstrapVersion = "5.19.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "simple-reactivemongo"      % "8.0.0-play-28",
     "uk.gov.hmrc"       %% "mongo-lock"                % "7.0.0-play-28",
     "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % bootstrapVersion,
-    "org.typelevel"     %% "cats-core"                 % "2.6.1",
+    "org.typelevel"     %% "cats-core"                 % "2.7.0",
     "com.chuusai"       %% "shapeless"                 % "2.3.7",
     "org.reactivemongo" %% "reactivemongo-akkastream"  % "0.20.13"
   )
@@ -33,24 +33,24 @@ object AppDependencies {
     "com.typesafe.play"            %% "play-test"              % current          % "test",
     "org.pegdown"                  %  "pegdown"                % "1.6.0"          % "test, it",
     "org.scalatestplus.play"       %% "scalatestplus-play"     % "5.1.0"          % "test, it",
-    "org.scalamock"                %% "scalamock"              % "5.1.0"          % "test, it",
+    "org.scalamock"                %% "scalamock"              % "5.2.0"          % "test, it",
     "org.scalatestplus"            %% "scalacheck-1-15"        % "3.2.10.0"       % "test, it",
-    "com.github.tomakehurst"       %  "wiremock-jre8"          % "2.31.0"         % "test, it",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.12.5"         % "test, it",
+    "com.github.tomakehurst"       %  "wiremock-jre8"          % "2.32.0"         % "test, it",
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.13.1"         % "test, it",
     "com.miguno.akka"              %% "akka-mock-scheduler"    % "0.5.5"          % "test, it",
-    "com.typesafe.akka"            %% "akka-testkit"           % "2.6.17"         % "test, it"
+    "com.typesafe.akka"            %% "akka-testkit"           % "2.6.18"         % "test, it"
   )
 
   // Fixes a transitive dependency clash after upgrading to sbt 1.3.4
   val overrides: Seq[ModuleID] = {
     val jettyFromWiremockVersion = "9.4.44.v20210927"
     Seq(
-      "com.typesafe.akka"           %% "akka-actor"                 % "2.6.17",
-      "com.typesafe.akka"           %% "akka-stream"                % "2.6.17",
-      "com.typesafe.akka"           %% "akka-protobuf"              % "2.6.17",
-      "com.typesafe.akka"           %% "akka-slf4j"                 % "2.6.17",
-      "com.typesafe.akka"           %% "akka-serialization-jackson" % "2.6.17",
-      "com.typesafe.akka"           %% "akka-actor-typed"           % "2.6.17",
+      "com.typesafe.akka"           %% "akka-actor"                 % "2.6.18",
+      "com.typesafe.akka"           %% "akka-stream"                % "2.6.18",
+      "com.typesafe.akka"           %% "akka-protobuf"              % "2.6.18",
+      "com.typesafe.akka"           %% "akka-slf4j"                 % "2.6.18",
+      "com.typesafe.akka"           %% "akka-serialization-jackson" % "2.6.18",
+      "com.typesafe.akka"           %% "akka-actor-typed"           % "2.6.18",
       "org.eclipse.jetty"           % "jetty-client"       % jettyFromWiremockVersion,
       "org.eclipse.jetty"           % "jetty-continuation" % jettyFromWiremockVersion,
       "org.eclipse.jetty"           % "jetty-http"         % jettyFromWiremockVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,13 +3,13 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -9,7 +9,7 @@
  <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
   <parameters>
    <parameter name="header"><![CDATA[/*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/config/MockAppConfig.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/config/MockAppConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/connectors/ApiSubscriptionFieldsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/connectors/ApiSubscriptionFieldsConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/connectors/MockApiSubscriptionFieldsConnector.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/connectors/MockApiSubscriptionFieldsConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/connectors/MockAuthConnector.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/connectors/MockAuthConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/AuthorisedControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/AuthorisedControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/DocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/DocumentationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/HousekeepingControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/HousekeepingControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeRetrievalControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeRetrievalControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeSubmissionControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/OutcomeSubmissionControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/test/TestOutcomeRetrievalControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/test/TestOutcomeRetrievalControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/models/FullOutcomeSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/models/FullOutcomeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/MockReportSender.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/MockReportSender.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/OutcomeReportSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/OutcomeReportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/ReportSenderSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/ReportSenderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/audit/AuditHandlerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/audit/AuditHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/audit/MockAuditHandler.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/audit/MockAuditHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/events/EventConnectorSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/events/EventConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/events/MockEventConnector.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/reporting/events/MockEventConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/repositories/MockHousekeepingRepo.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/repositories/MockHousekeepingRepo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/repositories/MockOutcomeRepo.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/repositories/MockOutcomeRepo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/services/AuthServiceSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/services/AuthServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/services/HousekeepingServiceSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/services/HousekeepingServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/services/MockAuthService.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/services/MockAuthService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/services/MockHousekeepingService.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/services/MockHousekeepingService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/services/MockOutcomeRetrievalService.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/services/MockOutcomeRetrievalService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/services/MockOutcomeSubmissionService.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/services/MockOutcomeSubmissionService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/services/OutcomeRetrievalServiceSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/services/OutcomeRetrievalServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/services/OutcomeSubmissionServiceSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/services/OutcomeSubmissionServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/utils/EnumJsonSpecSupport.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/utils/EnumJsonSpecSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/utils/EnumsSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/utils/EnumsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/utils/MockMetrics.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/utils/MockMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/utils/MockPagerDutyLogger.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/utils/MockPagerDutyLogger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/utils/TimerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/utils/TimerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Copyright updates for 2022
Dependency and plugin updates

Note - unable to upgrade reactivemongo-akkastream without breaking changes for any version later than current