### PR TITLE
 refactor(DL-16084): Addressed PlatOps comments

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.9.4
+version = 3.9.6
 runner.dialect = scala213
 
 maxColumn = 120

--- a/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/api/DocumentationController.scala
+++ b/app/uk/gov/hmrc/entrydeclarationoutcome/controllers/api/DocumentationController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.entrydeclarationoutcome.controllers
+package uk.gov.hmrc.entrydeclarationoutcome.controllers.api
 
 import controllers.Assets
 import play.api.libs.json.Json

--- a/conf/api.routes
+++ b/conf/api.routes
@@ -1,4 +1,4 @@
 # microservice specific routes
 
-GET         /api/definition                                        uk.gov.hmrc.entrydeclarationoutcome.controllers.DocumentationController.definition()
-GET         /api/conf/:version/*file                               uk.gov.hmrc.entrydeclarationoutcome.controllers.DocumentationController.conf(version: String, file: String)
+GET         /api/definition                                        uk.gov.hmrc.entrydeclarationoutcome.controllers.api.DocumentationController.definition()
+GET         /api/conf/:version/*file                               uk.gov.hmrc.entrydeclarationoutcome.controllers.api.DocumentationController.conf(version: String, file: String)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -18,6 +18,7 @@ import sbt.*
 object AppDependencies {
   val bootstrapVersion = "9.11.0"
   val hmrcMongoVersion = "2.6.0"
+  val pekkoVersion = "1.1.3"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"        % hmrcMongoVersion,
@@ -30,13 +31,18 @@ object AppDependencies {
     "uk.gov.hmrc"                  %% "bootstrap-test-play-30"  % bootstrapVersion % Test,
     "uk.gov.hmrc.mongo"            %% "hmrc-mongo-test-play-30" % hmrcMongoVersion % Test,
     "org.scalatestplus.play"       %% "scalatestplus-play"      % "7.0.1"          % Test,
-    "org.scalamock"                %% "scalamock"               % "7.3.0"          % Test,
+    "org.scalamock"                %% "scalamock"               % "7.3.2"          % Test,
     "org.scalatestplus"            %% "scalacheck-1-18"         % "3.2.19.0"       % Test,
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"    % "2.18.3"         % Test,
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"    % "2.19.0"         % Test,
   )
 
   val itDependencies: Seq[ModuleID] = Seq(
-    "com.github.pjfanning" %% "pekko-mock-scheduler" % "0.6.0" % Test,
-    "org.apache.pekko"     %% "pekko-testkit"        % "1.0.3" % Test
+    "com.github.pjfanning" %% "pekko-mock-scheduler"        % "0.6.0"       % Test,
+    "org.apache.pekko"     %% "pekko-testkit"               % pekkoVersion  % Test,
+    "org.apache.pekko"     %% "pekko-actor-typed"           % pekkoVersion  % Test,
+    "org.apache.pekko"     %% "pekko-protobuf-v3"           % pekkoVersion  % Test,
+    "org.apache.pekko"     %% "pekko-serialization-jackson" % pekkoVersion  % Test,
+    "org.apache.pekko"     %% "pekko-slf4j"                 % pekkoVersion  % Test,
+    "org.apache.pekko"     %% "pekko-stream"                % pekkoVersion  % Test
   )
 }

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/DocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/DocumentationControllerSpec.scala
@@ -29,6 +29,7 @@ import play.api.test.{FakeRequest, Helpers, Injecting}
 import play.api.{Application, Environment, Mode}
 import play.mvc.Http.MimeTypes
 import uk.gov.hmrc.entrydeclarationoutcome.config.MockAppConfig
+import uk.gov.hmrc.entrydeclarationoutcome.controllers.api.DocumentationController
 import uk.gov.hmrc.entrydeclarationoutcome.housekeeping.HousekeepingScheduler
 
 class DocumentationControllerSpec extends AnyWordSpec with MockAppConfig with Injecting with GuiceOneAppPerSuite {

--- a/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/api/DocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationoutcome/controllers/api/DocumentationControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.entrydeclarationoutcome.controllers
+package uk.gov.hmrc.entrydeclarationoutcome.controllers.api
 
 import controllers.Assets
 import org.scalatest.Assertion
@@ -29,7 +29,6 @@ import play.api.test.{FakeRequest, Helpers, Injecting}
 import play.api.{Application, Environment, Mode}
 import play.mvc.Http.MimeTypes
 import uk.gov.hmrc.entrydeclarationoutcome.config.MockAppConfig
-import uk.gov.hmrc.entrydeclarationoutcome.controllers.api.DocumentationController
 import uk.gov.hmrc.entrydeclarationoutcome.housekeeping.HousekeepingScheduler
 
 class DocumentationControllerSpec extends AnyWordSpec with MockAppConfig with Injecting with GuiceOneAppPerSuite {


### PR DESCRIPTION
Addressed the previous PlatOps comment which looked like

> You have multiple routes files conf/api.routes, conf/app.routes using the same package uk.gov.hmrc.entrydeclarationoutcome.controllers, which leads to collision with the reverse routes. Please ensure each routes file refers to a different package.